### PR TITLE
added package data to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include requirements.txt
+include randd/model/egrd/basis/*.npz
+include docs/source/_static/*.png

--- a/randd/__init__.py
+++ b/randd/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 
 from .analyzer import Analyzer, Profile, Summary

--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,5 @@ setuptools.setup(
         "Bug Reports": "https://github.com/UWIVC/randd/issues",
         "Source": "https://github.com/UWIVC/randd/",
     },
-    package_data={
-        "randd": ["*.npz"],
-        "docs": ["*.png"],
-    },
+    include_package_data=True,
 )


### PR DESCRIPTION
- added package data to manifest
- run `pip install build`, `python -m build`, and `pip install dist/randd-0.2.2-py3-none-any.whl` to install the package. Then you should be able to see the data files in ~/anaconda3/envs/randd/lib/python3.10/site-packages/randd/model/egrd/basis, assuming your env is named `randd` and your python version is 3.10.